### PR TITLE
Break system packages

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -372,7 +372,13 @@ function ici_install_dependencies {
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
-    export PIP_BREAK_SYSTEM_PACKAGES=1
+
+    # rosdep needs to be able to install to the system packages directory for Python versions > 3.10
+    local p=$(python3 -c 'import sys; print(sys.version_info[0] > 2 and sys.version_info[1] > 10)'>&1) 
+    if [ $p == "True" ]; then
+      export PIP_BREAK_SYSTEM_PACKAGES=1
+    fi
+
     ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}"
 }
 

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -372,8 +372,8 @@ function ici_install_dependencies {
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
-
-    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install "${rosdep_opts[@]}"
+    export PIP_BREAK_SYSTEM_PACKAGES=1
+    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}"
 }
 
 function ici_build_workspace {


### PR DESCRIPTION
Allows breaking system packages with rosdep for Python versions newer than 3.10 to address the problem discussed here: https://discourse.ros.org/t/rosdep-for-pip-is-broken-on-jazzy/38981/8